### PR TITLE
Update messaging_interactions, add two new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It:
   - [Users](https://developers.liveperson.com/users-api-methods-get-all-users.html)
   - [Agent Activity](https://developers.liveperson.com/data-access-api-methods-agent-activity.html)
   - [Queue Health](https://developers.liveperson.com/operational-realtime-api-methods-queue-health.html)
+  - [Messaging Queue Health](https://developers.liveperson.com/messaging-operations-api-methods-messaging-queue-health.html)
+  - [Agent Activity](https://developers.liveperson.com/operational-realtime-api-methods-agent-activity.html)
 
 ### Quick Start
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-liveperson',
-      version='0.0.3',
+      version='0.0.4',
       description='Singer.io tap for extracting data from the LivePerson API',
       author='Fishtown Analytics',
       url='http://fishtownanalytics.com',

--- a/tap_liveperson/schemas/agent_state_distribution.json
+++ b/tap_liveperson/schemas/agent_state_distribution.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "timestamp": {
+        "type": "integer"
+    },
+    "metricsData": {}
+  }
+}

--- a/tap_liveperson/schemas/messaging_interactions.json
+++ b/tap_liveperson/schemas/messaging_interactions.json
@@ -541,6 +541,68 @@
           "type": ["null", "integer"]
         }
       }
+    },
+    "monitoring": {
+      "type": "object",
+      "properties": {
+        "country": {
+          "type": ["null", "string"]
+        },
+        "countryCode": {
+          "type": ["null", "string"]
+        },
+        "state": {
+          "type": ["null", "string"]
+        },
+        "city": {
+          "type": ["null", "string"]
+        },
+        "isp": {
+          "type": ["null", "string"]
+        },
+        "org": {
+          "type": ["null", "string"]
+        },
+        "device": {
+          "type": ["null", "string"]
+        },
+        "ipAddress": {
+          "type": ["null", "string"]
+        },
+        "browser": {
+          "type": ["null", "string"]
+        },
+        "operatingSystem": {
+          "type": ["null", "string"]
+        },
+        "conversationStartPage": {
+          "type": ["null", "string"]
+        },
+        "conversationStartPageTitle": {
+          "type": ["null", "string"]
+        }
+      }
+    },
+    "unAuthSdes": {
+      "type": "object",
+      "properties": {
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "purchase": {},
+              "cartStatus": {},
+              "customerInfo": {},
+              "personalInfo": {},
+              "sdeType": {},
+              "serverTimeStamp": {
+                "type": ["null", "integer"]
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/tap_liveperson/schemas/messaging_queue_health.json
+++ b/tap_liveperson/schemas/messaging_queue_health.json
@@ -1,0 +1,65 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+        "type": "string"
+    },
+    "skill": {
+        "type": "string"
+    },
+    "timestamp": {
+        "type": "integer"
+    },
+    "unassignedConversations": {
+        "type": "number"
+    },
+    "actionableConversations": {
+        "type": "number"
+    },
+    "notActionableConversations": {
+        "type": "number"
+    },
+    "actionableAndManualSla": {
+        "type": "number"
+    },
+    "actionableAndDuringTransfer": {
+        "type": "number"
+    },
+    "actionableAndConsumerLastMessage": {
+        "type": "number"
+    },
+    "notActionableDuringTransfer": {
+        "type": "number"
+    },
+    "notActionableAndManualSla": {
+        "type": "number"
+    },
+    "unassignedConversationsAndFirstTimeConsumer": {
+        "type": "number"
+    },
+    "avgWaitTimeForAgentAssignment_NewConversation": {
+        "type": "number"
+    },
+    "avgWaitTimeForAgentAssignment_AfterTransfer": {
+        "type": "number"
+    },
+    "avgWaitTimeForAgentAssignment_AfterTransferFromBot": {
+        "type": "number"
+    },
+    "maxWaitTimeForAgentAssignment": {
+        "type": "number"
+    },
+    "waitTimeForAgentAssignment_50thPercentile": {
+        "type": "number"
+    },
+    "waitTimeForAgentAssignment_90thPercentile": {
+        "type": "number"
+    },
+    "avgWaitTimeForAgentAssignment_AfterTransferFromAgent": {
+        "type": "number"
+    },
+    "maxWaitTimeForAgentAssignment_AfterTransferFromAgent": {
+        "type": "number"      
+    }
+  }
+}

--- a/tap_liveperson/schemas/messaging_queue_health.json
+++ b/tap_liveperson/schemas/messaging_queue_health.json
@@ -2,64 +2,64 @@
   "type": "object",
   "properties": {
     "id": {
-        "type": "string"
+        "type": ["string", "null"]
     },
     "skill": {
-        "type": "string"
+        "type": ["string", "null"]
     },
     "timestamp": {
-        "type": "integer"
+        "type": ["integer", "null"]
     },
     "unassignedConversations": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "actionableConversations": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "notActionableConversations": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "actionableAndManualSla": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "actionableAndDuringTransfer": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "actionableAndConsumerLastMessage": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "notActionableDuringTransfer": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "notActionableAndManualSla": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "unassignedConversationsAndFirstTimeConsumer": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "avgWaitTimeForAgentAssignment_NewConversation": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "avgWaitTimeForAgentAssignment_AfterTransfer": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "avgWaitTimeForAgentAssignment_AfterTransferFromBot": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "maxWaitTimeForAgentAssignment": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "waitTimeForAgentAssignment_50thPercentile": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "waitTimeForAgentAssignment_90thPercentile": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "avgWaitTimeForAgentAssignment_AfterTransferFromAgent": {
-        "type": "number"
+        "type": ["number", "null"]
     },
     "maxWaitTimeForAgentAssignment_AfterTransferFromAgent": {
-        "type": "number"      
+        "type": ["number", "null"]
     }
   }
 }

--- a/tap_liveperson/streams/__init__.py
+++ b/tap_liveperson/streams/__init__.py
@@ -5,6 +5,10 @@ from tap_liveperson.streams.agent_activity \
     import AgentActivityStream
 from tap_liveperson.streams.queue_health \
     import QueueHealthStream
+from tap_liveperson.streams.agent_state_distribution \
+    import AgentStateDistribution
+from tap_liveperson.streams.messaging_queue_health \
+    import MessagingQueueHealthStream
 
 from tap_liveperson.streams.agent_groups import AgentGroupsStream
 from tap_liveperson.streams.agent_status import AgentStatusStream
@@ -19,7 +23,9 @@ AVAILABLE_STREAMS = [
     EngagementHistoryStream,
     MessagingInteractionsStream,
     AgentActivityStream,
-    QueueHealthStream
+    QueueHealthStream,
+    AgentStateDistribution,
+    MessagingQueueHealthStream
 ]
 
 __all__ = [
@@ -31,4 +37,6 @@ __all__ = [
     'MessagingInteractionsStream',
     'AgentActivityStream',
     'QueueHealthStream',
+    'AgentStateDistribution',
+    'MessagingQueueHealthStream'
 ]

--- a/tap_liveperson/streams/agent_state_distribution.py
+++ b/tap_liveperson/streams/agent_state_distribution.py
@@ -1,0 +1,36 @@
+from tap_liveperson.streams.base import RealtimeStream
+
+
+class AgentStateDistribution(RealtimeStream):
+    API_METHOD = 'GET'
+    SERVICE_NAME = 'leDataReporting'
+    TABLE = 'agent_state_distribution'
+
+    @property
+    def api_path(self):
+        return (
+            '/operations/api/account/{}/agentactivity'
+            .format(self.config.get('account_id')))
+
+    def get_params(self):
+        return {
+            "timeframe": 1440,
+            "interval": 5,
+            "agentIds": "all",
+            "v": 2
+        }
+
+    def get_stream_data(self, result):
+        metrics_body = result.get('body', {})
+        transformed = [
+            self.transform_record(record)
+            for record in metrics_body.get('metricsByIntervals', [])
+        ]
+
+        for record in transformed:
+            record['id'] = self.get_pk_value(record)
+
+        return transformed
+
+    def get_pk_value(self, obj):
+        return obj.get('timestamp')

--- a/tap_liveperson/streams/base.py
+++ b/tap_liveperson/streams/base.py
@@ -54,10 +54,9 @@ class BaseStream(base):
         }
 
     def get_content_to_retrieve(self):
-        try:
-            return {"contentToRetrieve": self.CONTENT_TO_RETRIEVE}
-        except:
-            return {}
+        if self.CONTENT_TO_RETRIEVE:
+          return {"contentToRetrieve": self.CONTENT_TO_RETRIEVE}
+        return {}
 
     def get_filters(self, start, end):
         return {

--- a/tap_liveperson/streams/base.py
+++ b/tap_liveperson/streams/base.py
@@ -53,6 +53,12 @@ class BaseStream(base):
             'sort': 'start:asc',
         }
 
+    def get_content_to_retrieve(self):
+        try:
+            return {"contentToRetrieve": self.CONTENT_TO_RETRIEVE}
+        except:
+            return {}
+
     def get_filters(self, start, end):
         return {
             'start': {
@@ -86,6 +92,7 @@ class BaseStream(base):
 
             params = self.get_pagination(page)
             body = self.get_filters(updated_after, updated_before)
+            body.update(self.get_content_to_retrieve())
 
             result = self.client.make_request(
                 url, self.API_METHOD, params=params, body=body)

--- a/tap_liveperson/streams/messaging_interactions.py
+++ b/tap_liveperson/streams/messaging_interactions.py
@@ -6,10 +6,16 @@ class MessagingInteractionsStream(BaseStream):
     SERVICE_NAME = 'msgHist'
     TABLE = 'messaging_interactions'
 
+    CONTENT_TO_RETRIEVE = ['campaign', 'messageRecords', 'agentParticipants',
+            'agentParticipantsLeave', 'agentParticipantsActive',
+            'consumerParticipants', 'transfers', 'interactions',
+            'messageScores', 'messageStatuses', 'conversationSurveys',
+            'coBrowseSessions', 'summary', 'sdes', 'unAuthSdes', 'monitoring']
+
     @property
     def api_path(self):
         return (
-            '/messaging_history/api/account/{}/conversations/search'
+            '/messaging_history/api/account/{}/conversations/search?v=2'
             .format(self.config.get('account_id')))
 
     def get_stream_data(self, result):

--- a/tap_liveperson/streams/messaging_queue_health.py
+++ b/tap_liveperson/streams/messaging_queue_health.py
@@ -1,0 +1,42 @@
+from tap_liveperson.streams.base import RealtimeStream
+
+
+class MessagingQueueHealthStream(RealtimeStream):
+    API_METHOD = 'GET'
+    SERVICE_NAME = 'leDataReporting'
+    TABLE = 'messaging_queue_health'
+
+    @property
+    def api_path(self):
+        return (
+            '/operations/api/account/{}/msgqueuehealth'
+            .format(self.config.get('account_id')))
+
+    def get_params(self):
+        return {
+            "timeframe": 1440,
+            "interval": 5,
+            "skillIds": "all",
+            "v": 2
+        }
+
+    def get_stream_data(self, result):
+
+        metrics_by_skill = result.get('metricsByIntervals', [])
+
+        transformed = []
+        for records in metrics_by_skill:
+            timestamp = records['timestamp']
+            for skill, data in records['metricsData']['skillsMetrics'].items():
+                new_row = self.transform_record(data)
+
+                new_row['id'] = self.get_pk_value(skill, timestamp)
+                new_row['skill'] = skill
+                new_row['timestamp'] = timestamp
+
+                transformed.append(new_row)
+
+        return transformed
+
+    def get_pk_value(self, skill, timestamp):
+        return "{}@{}".format(skill, timestamp)

--- a/tap_liveperson/streams/messaging_queue_health.py
+++ b/tap_liveperson/streams/messaging_queue_health.py
@@ -27,7 +27,7 @@ class MessagingQueueHealthStream(RealtimeStream):
         transformed = []
         for records in metrics_by_skill:
             timestamp = records['timestamp']
-            for skill, data in records['metricsData']['skillsMetrics'].items():
+            for skill, data in records.get('metricsData', {}).get('skillsMetrics', {}).items():
                 new_row = self.transform_record(data)
 
                 new_row['id'] = self.get_pk_value(skill, timestamp)


### PR DESCRIPTION
# Description of change

- [x] update `messaging_interactions` endpoint by upgrading to API v2 and starting to explicitly list [contentToRetrieve](https://developers.liveperson.com/messaging-interactions-api-methods-conversations.html#note-new-capability---partial-retrieval-of-data) - in this case, there are two new columns added above default, i.e. `"unAuthSdes"` and `"monitoring"`. This allows to see sell conversion.
- [x] add new endpoint: `agent_state_distribution`: https://developers.liveperson.com/operational-realtime-api-methods-agent-activity.html
- [x] add new endpoint: `messaging_queue_health`: https://developers.liveperson.com/messaging-operations-api-methods-messaging-queue-health.html

# Manual QA steps
 - example JSON outputs have been sense-checked as well as data loaded to Snowflake via `target-stitch`
 
# Risks
 - two new columns are added to `messaging_interactions` table which may cause backward compatibility issues
 
# Rollback steps
 - revert this branch
