### PR TITLE
Coerce timestamp-id to string

### DIFF
--- a/tap_liveperson/streams/agent_state_distribution.py
+++ b/tap_liveperson/streams/agent_state_distribution.py
@@ -28,7 +28,7 @@ class AgentStateDistribution(RealtimeStream):
         ]
 
         for record in transformed:
-            record['id'] = self.get_pk_value(str(record))
+            record['id'] = str(self.get_pk_value(record))
 
         return transformed
 

--- a/tap_liveperson/streams/agent_state_distribution.py
+++ b/tap_liveperson/streams/agent_state_distribution.py
@@ -28,7 +28,7 @@ class AgentStateDistribution(RealtimeStream):
         ]
 
         for record in transformed:
-            record['id'] = self.get_pk_value(record)
+            record['id'] = self.get_pk_value(str(record))
 
         return transformed
 


### PR DESCRIPTION
# Description of change
`id` is expected to be a string - in this case it's an epoch timestamp (integer).
